### PR TITLE
Add install targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,18 +9,72 @@ if (EXISTS CACHE{VCPKG_MANIFEST_FILE})
     vcpkg_acquire_dependencies()
 endif()
 
-add_library(ffgl_sdk STATIC)
-add_library(ffgl::sdk ALIAS ffgl_sdk)
-target_sources(ffgl_sdk PUBLIC source/lib/FFGLSDK.h)
-target_sources(ffgl_sdk PRIVATE source/lib/FFGLSDK.cpp)
+add_library(ffgl-sdk STATIC
+    source/lib/FFGLSDK.h
+    source/lib/FFGLSDK.cpp
+)
 
-target_include_directories(ffgl_sdk PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/source/lib/")
+add_library(ffgl::sdk ALIAS ffgl-sdk)
+set_target_properties(ffgl-sdk PROPERTIES EXPORT_NAME sdk)
+
+target_include_directories(ffgl-sdk PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/source/lib/>
+    $<INSTALL_INTERFACE:include>
+)
+
+target_compile_features(ffgl-sdk PUBLIC cxx_std_11)
 
 # we need glew (except on macOS)
 if (NOT APPLE)
     find_package(GLEW REQUIRED)
-    target_link_libraries(ffgl_sdk PRIVATE GLEW::GLEW)
+    target_link_libraries(ffgl-sdk PRIVATE GLEW::GLEW)
 endif()
+
+include(GNUInstallDirs)
+
+install(
+    DIRECTORY source/lib/ffgl
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    FILES_MATCHING PATTERN "*.h"
+)
+
+install(
+    TARGETS     ffgl-sdk
+    EXPORT      ffgl-sdk-targets
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+
+install(
+    EXPORT      ffgl-sdk-targets
+    NAMESPACE   ffgl::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ffgl-sdk
+)
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/ffgl-sdk/ffgl-sdk-config-version.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY AnyNewerVersion
+)
+
+export(
+    EXPORT      ffgl-sdk-targets
+    FILE        "${CMAKE_CURRENT_BINARY_DIR}/ffgl-sdk/ffgl-sdk-targets.cmake"
+    NAMESPACE   ffgl::
+)
+
+configure_file(cmake/ffgl-sdk-config.cmake
+    "${CMAKE_CURRENT_BINARY_DIR}/ffgl-sdk/ffgl-sdk-config-version.cmake"
+    COPYONLY
+)
+
+install(
+    FILES
+        cmake/ffgl-sdk-config.cmake
+        "${CMAKE_CURRENT_BINARY_DIR}/ffgl-sdk/ffgl-sdk-config-version.cmake"
+    DESTINATION
+        ${CMAKE_INSTALL_LIBDIR}/cmake/ffgl-sdk
+)
 
 # are we building ffgl as the main repo, or is it included
 # into another project?

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,9 @@
+Copyright 2023 FreeFrame
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/cmake/ffgl-sdk-config.cmake
+++ b/cmake/ffgl-sdk-config.cmake
@@ -1,0 +1,1 @@
+include("${CMAKE_CURRENT_LIST_DIR}/ffgl-sdk-targets.cmake")

--- a/source/plugins/Add/CMakeLists.txt
+++ b/source/plugins/Add/CMakeLists.txt
@@ -1,4 +1,10 @@
-add_library(ffgl_plugin_add STATIC)
-add_library(ffgl::plugin::add ALIAS ffgl_plugin_add)
-target_sources(ffgl_plugin_add PRIVATE Add.h Add.cpp)
-target_link_libraries(ffgl_plugin_add PRIVATE ffgl::sdk)
+add_library(ffgl-plugin-add STATIC)
+add_library(ffgl::plugin::add ALIAS ffgl-plugin-add)
+target_sources(ffgl-plugin-add PRIVATE Add.h Add.cpp)
+target_link_libraries(ffgl-plugin-add PRIVATE ffgl::sdk)
+
+install(
+    TARGETS     ffgl-plugin-add
+    EXPORT      ffgl-plugin-add-targets
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)

--- a/source/plugins/AddSubtract/CMakeLists.txt
+++ b/source/plugins/AddSubtract/CMakeLists.txt
@@ -1,4 +1,10 @@
-add_library(ffgl_plugin_add_subtract STATIC)
-add_library(ffgl::plugin::add_subtract ALIAS ffgl_plugin_add_subtract)
-target_sources(ffgl_plugin_add_subtract PRIVATE AddSubtract.h AddSubtract.cpp)
-target_link_libraries(ffgl_plugin_add_subtract PRIVATE ffgl::sdk)
+add_library(ffgl-plugin-add-subtract STATIC)
+add_library(ffgl::plugin::add_subtract ALIAS ffgl-plugin-add-subtract)
+target_sources(ffgl-plugin-add-subtract PRIVATE AddSubtract.h AddSubtract.cpp)
+target_link_libraries(ffgl-plugin-add-subtract PRIVATE ffgl::sdk)
+
+install(
+    TARGETS     ffgl-plugin-add-subtract
+    EXPORT      ffgl--plugin-add-subtract-targets
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)

--- a/source/plugins/CustomThumbnail/CMakeLists.txt
+++ b/source/plugins/CustomThumbnail/CMakeLists.txt
@@ -1,7 +1,7 @@
-add_library(ffgl_plugin_custom_thumbnails STATIC)
-add_library(ffgl::plugin::custom_thumbnails ALIAS ffgl_plugin_custom_thumbnails)
+add_library(ffgl-plugin-custom-thumbnails STATIC)
+add_library(ffgl::plugin::custom-thumbnails ALIAS ffgl-plugin-custom-thumbnails)
 
-target_sources(ffgl_plugin_custom_thumbnails PRIVATE
+target_sources(ffgl-plugin-custom-thumbnails PRIVATE
     CustomThumbnail.h   CustomThumbnail.cpp
     PNGLoader.h         PNGLoader.cpp
     Thumb.h
@@ -10,8 +10,14 @@ target_sources(ffgl_plugin_custom_thumbnails PRIVATE
 find_package(PNG REQUIRED)
 find_package(ZLIB REQUIRED)
 
-target_link_libraries(ffgl_plugin_custom_thumbnails PRIVATE PNG::PNG)
-target_link_libraries(ffgl_plugin_custom_thumbnails PRIVATE ZLIB::ZLIB)
+target_link_libraries(ffgl-plugin-custom-thumbnails PRIVATE PNG::PNG)
+target_link_libraries(ffgl-plugin-custom-thumbnails PRIVATE ZLIB::ZLIB)
 
-target_link_libraries(ffgl_plugin_custom_thumbnails PRIVATE ffgl::sdk)
-target_link_libraries(ffgl_plugin_custom_thumbnails PRIVATE png_static)
+target_link_libraries(ffgl-plugin-custom-thumbnails PRIVATE ffgl::sdk)
+target_link_libraries(ffgl-plugin-custom-thumbnails PRIVATE png_static)
+
+install(
+    TARGETS     ffgl-plugin-custom-thumbnails
+    EXPORT      ffgl--plugin-custom-thumbnails-targets
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)

--- a/source/plugins/Events/CMakeLists.txt
+++ b/source/plugins/Events/CMakeLists.txt
@@ -1,4 +1,10 @@
-add_library(ffgl_plugin_events STATIC)
-add_library(ffgl::plugin::events ALIAS ffgl_plugin_events)
-target_sources(ffgl_plugin_events PRIVATE FFGLEvents.h FFGLEvents.cpp)
-target_link_libraries(ffgl_plugin_events PRIVATE ffgl::sdk)
+add_library(ffgl-plugin-events STATIC)
+add_library(ffgl::plugin::events ALIAS ffgl-plugin-events)
+target_sources(ffgl-plugin-events PRIVATE FFGLEvents.h FFGLEvents.cpp)
+target_link_libraries(ffgl-plugin-events PRIVATE ffgl::sdk)
+
+install(
+    TARGETS     ffgl-plugin-events
+    EXPORT      ffgl--plugin-events-targets
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)

--- a/source/plugins/Gradients/CMakeLists.txt
+++ b/source/plugins/Gradients/CMakeLists.txt
@@ -1,4 +1,10 @@
-add_library(ffgl_plugin_gradients STATIC)
-add_library(ffgl::plugin::gradients ALIAS ffgl_plugin_events)
-target_sources(ffgl_plugin_gradients PRIVATE FFGLGradients.h FFGLGradients.cpp)
-target_link_libraries(ffgl_plugin_gradients PRIVATE ffgl::sdk)
+add_library(ffgl-plugin-gradients STATIC)
+add_library(ffgl::plugin::gradients ALIAS ffgl-plugin-gradients)
+target_sources(ffgl-plugin-gradients PRIVATE FFGLGradients.h FFGLGradients.cpp)
+target_link_libraries(ffgl-plugin-gradients PRIVATE ffgl::sdk)
+
+install(
+    TARGETS     ffgl-plugin-gradients
+    EXPORT      ffgl--plugin-gradients-targets
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)

--- a/source/plugins/Particles/CMakeLists.txt
+++ b/source/plugins/Particles/CMakeLists.txt
@@ -1,6 +1,6 @@
-add_library(ffgl_plugin_particles STATIC)
-add_library(ffgl::plugin::particles ALIAS ffgl_plugin_particles)
-target_sources(ffgl_plugin_particles PRIVATE
+add_library(ffgl-plugin-particles STATIC)
+add_library(ffgl::plugin::particles ALIAS ffgl-plugin-particles)
+target_sources(ffgl-plugin-particles PRIVATE
     Constants.h     Constants.cpp
     GLResources.h   GLResources.cpp
     Particles.h     Particles.cpp
@@ -9,4 +9,10 @@ target_sources(ffgl_plugin_particles PRIVATE
     shaders/vsRender.h
     shaders/vsUpdate.h
 )
-target_link_libraries(ffgl_plugin_particles PRIVATE ffgl::sdk)
+target_link_libraries(ffgl-plugin-particles PRIVATE ffgl::sdk)
+
+install(
+    TARGETS     ffgl-plugin-particles
+    EXPORT      ffgl--plugin-particles-targets
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)


### PR DESCRIPTION
This adds the `install` target to the CMake-generated project. It also allows finding the install FFGL SDK using `find_package()`.

Targets are renamed to use dashes instead of underscores, as this matches better with the prefixes mandated by CMake - e.g. for exported target names. Without this change, you'd get something like `ffgl_sdk-targets`.