### PR TITLE
Fix for FFGLFbo doesn't delete texture during clean

### DIFF
--- a/source/lib/ffglex/FFGLFBO.cpp
+++ b/source/lib/ffglex/FFGLFBO.cpp
@@ -66,10 +66,10 @@ void FFGLFBO::Release()
 		depthBufferID = 0;
 	}
 
-	if( depthBufferID != 0 )
+	if( colorTextureID != 0 )
 	{
-		glDeleteTextures( 1, &depthBufferID );
-		depthBufferID = 0;
+		glDeleteTextures( 1, &colorTextureID );
+		colorTextureID = 0;
 	}
 }
 


### PR DESCRIPTION
During Release, FFGLFbo checks the depthbufferid twice, so it never deletes its color texture