### PR TITLE
Adds missing FBO binding header

### DIFF
--- a/source/lib/FFGLSDK.h
+++ b/source/lib/FFGLSDK.h
@@ -8,6 +8,7 @@
 #include "ffglex/FFGLFBO.h"
 #include "ffglex/FFGLScopedBufferBinding.h"
 #include "ffglex/FFGLScopedSamplerActivation.h"
+#include "ffglex/FFGLScopedFBOBinding.h"
 #include "ffglex/FFGLScopedShaderBinding.h"
 #include "ffglex/FFGLScopedTextureBinding.h"
 #include "ffglex/FFGLScopedVAOBinding.h"


### PR DESCRIPTION
Adds the FFGLScopedFBOBinding header file to FFGLSDK.h.
