### PR TITLE
Fix FFGLFBO::Release leaking the color texture

### DIFF
--- a/source/lib/ffglex/FFGLFBO.cpp
+++ b/source/lib/ffglex/FFGLFBO.cpp
@@ -66,10 +66,10 @@ void FFGLFBO::Release()
 		depthBufferID = 0;
 	}
 
-	if( depthBufferID != 0 )
+	if( colorTextureID != 0 )
 	{
-		glDeleteTextures( 1, &depthBufferID );
-		depthBufferID = 0;
+		glDeleteTextures( 1, &colorTextureID );
+		colorTextureID = 0;
 	}
 }
 


### PR DESCRIPTION
`FFGLFBO::Release()` has two consecutive blocks guarded on `depthBufferID`:

```cpp
if( depthBufferID != 0 )
{
    glDeleteRenderbuffers( 1, &depthBufferID );
    depthBufferID = 0;
}

if( depthBufferID != 0 )
{
    glDeleteTextures( 1, &depthBufferID );
    depthBufferID = 0;
}
```

The first block zeroes `depthBufferID`, so the second is unreachable. It was
plainly meant to test and delete `colorTextureID`, which is therefore never
deleted — every `FFGLFBO` release leaks one texture.

That matters in practice because `Initialise()` calls `Release()` on its own
failure paths, and plugins that keep FBOs for intermediate passes release and
re-initialise them on every resolution change. The leaked textures are
full-size render targets, so it adds up over a session.

The fix is the three-line change to the second condition. No behaviour changes
beyond the texture now being deleted; if `colorTextureID` is already 0 the block
is skipped exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)