### PR TITLE
Fix swapped arguments for default build target list

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ endif()
 # should we build the example plugins? we do this by default
 # if building the project directly, but not when adding ffgl
 # to another project
-option(FFGL_BUILD_EXAMPLE_PLUGINS ${FFGL_MASTER_PROJECT} "Build the example FFGL plugins")
+option(FFGL_BUILD_EXAMPLE_PLUGINS "Build the example FFGL plugins" ${FFGL_MASTER_PROJECT})
 
 if (${FFGL_BUILD_EXAMPLE_PLUGINS})
     add_subdirectory(source/plugins)


### PR DESCRIPTION
The example plugins didn't build 'by default' without passing `-DFFGL_BUILD_EXAMPLE_PLUGINS=ON` explicitly.

When running `cmake -S . -B build && cmake --build build --target help` the `${FFGL_MASTER_PROJECT}` toggle fell in the help text slot, and the docstring landed in the `default` argument, never evaluated as true, so the default plugins never appeared in the targets list.

With this change, the plugins show up :

```sh
$ cmake -S . -B build && cmake --build build --target help
-- The CXX compiler identification is GNU 13.3.0
...
... rebuild_cache
... ffgl-plugin-add
... ffgl-plugin-add-subtract
... ffgl-plugin-custom-thumbnails
... ffgl-plugin-events
... ffgl-plugin-gradients
... ffgl-plugin-particles
... ffgl-sdk
... source/lib/FFGLSDK.o
...
```