### PR TITLE
Implement `Audio::GetVolumeFromTo` (was a stub returning 0.0)

### DIFF
--- a/source/lib/ffglquickstart/FFGLAudio.cpp
+++ b/source/lib/ffglquickstart/FFGLAudio.cpp
@@ -1,4 +1,5 @@
 #include "FFGLAudio.h"
+#include <algorithm>
 #include <cmath>
 #include "../ffglex/FFGLUtilities.h"
 
@@ -85,7 +86,29 @@ float Audio::GetHigh()
 
 float Audio::GetVolumeFromTo( int fromFreq, int toFreq )
 {
-	return 0.0f;
+	if( fft.empty() || sampleRate <= 0 )
+		return 0.0f;
+
+	if( fromFreq > toFreq )
+		std::swap( fromFreq, toFreq );
+
+	const int fftSize   = static_cast< int >( fft.size() );
+	const float binStep = freqMax / static_cast< float >( fftSize );
+
+	int fromBin = static_cast< int >( fromFreq / binStep );
+	int toBin   = static_cast< int >( std::ceil( toFreq / binStep ) );
+
+	//Clamp to the valid bin range, and make sure the range covers at least one bin even if it's
+	//narrower than a single bin's frequency width.
+	fromBin = std::min( std::max( fromBin, 0 ), fftSize - 1 );
+	toBin   = std::min( std::max( toBin, fromBin + 1 ), fftSize );
+
+	float sum = 0.0f;
+	for( int i = fromBin; i < toBin; i++ )
+		sum += fft[ i ] * fft[ i ] * gain;
+
+	sum /= static_cast< float >( toBin - fromBin );
+	return std::sqrt( sum );
 }
 
 float Audio::ToDB( float rms )
@@ -107,9 +130,8 @@ void Audio::SetSmoothness( float smoothness )
 
 void Audio::SetSampleRate( int _sampleRate )
 {
-	sampleRate  = _sampleRate;
-	freqMax     = (float)sampleRate / 2.f;
-	freqBinStep = freqMax / fft.size();
+	sampleRate = _sampleRate;
+	freqMax    = (float)sampleRate / 2.f;
 }
 
 void Audio::SetGain( float _gain )

--- a/source/lib/ffglquickstart/FFGLAudio.h
+++ b/source/lib/ffglquickstart/FFGLAudio.h
@@ -53,9 +53,9 @@ public:
 private:
 	std::vector< float > fft;
 	SmoothValue vol, bass, med, high;
-	float freqMax, freqBinStep;
-	int sampleRate;
-	float gain = 0;
+	float freqMax    = 0;
+	int sampleRate   = 0;
+	float gain       = 0;
 };
 
 }//End namespace ffglqs


### PR DESCRIPTION
Maps the requested Hz range to FFT bin indices using `freqMax/fft.size()` and reduces them the same way `Update()` already does for the bass/med/high bands (square, apply gain, mean, sqrt). Range args are order-independent and clamped to the valid bin range, with the range always covering at least one bin.

Also stops caching `freqBinStep` from `SetSampleRate`, since that could run before the first `Update()` call while `fft` was still empty `(freqMax / 0)`, and nothing recomputed it afterward if `fft`'s size changed. The equivalent bin step is now computed on demand from the always-current `fft.size()`.

Fixes #84