### PR TITLE
Cache uniform locations in `ffglex::FFGLShader`

### DIFF
--- a/source/lib/ffglex/FFGLShader.cpp
+++ b/source/lib/ffglex/FFGLShader.cpp
@@ -179,6 +179,8 @@ void FFGLShader::FreeGLResources()
 		glDeleteProgram( programID );
 		programID = 0;
 	}
+
+	uniformLocations.clear();
 }
 
 void FFGLShader::Set( const char* name, float value )
@@ -229,7 +231,13 @@ GLuint FFGLShader::GetGLID() const
  */
 GLint FFGLShader::FindUniform( const char* name ) const
 {
-	return glGetUniformLocation( programID, name );
+	auto it = uniformLocations.find( name );
+	if( it != uniformLocations.end() )
+		return it->second;
+
+	GLint location = glGetUniformLocation( programID, name );
+	uniformLocations[ name ] = location;
+	return location;
 }
 
 bool FFGLShader::CompileVertexShader( const char* vertexShader )
@@ -318,6 +326,9 @@ bool FFGLShader::CompileFragmentShader( const char* fragmentShader )
 }
 bool FFGLShader::LinkProgram()
 {
+	//Any cached uniform locations belong to the program we're about to replace, so they're no longer valid.
+	uniformLocations.clear();
+
 	programID = glCreateProgram();
 
 	glAttachShader( programID, vertexShaderID );

--- a/source/lib/ffglex/FFGLShader.h
+++ b/source/lib/ffglex/FFGLShader.h
@@ -3,6 +3,7 @@
 #include <vector>
 #include <string>
 #include <string>
+#include <unordered_map>
 
 namespace ffglex
 {
@@ -47,6 +48,7 @@ private:
 	GLuint fragmentShaderID;                             //!< The ID OpenGL gave our fragment shader. 0 for invalid.
 	GLuint programID;                                    //!< The ID OpenGL gave our shader program. Bind this to use this shader. 0 for invalid.
 	std::vector< std::string > transformFeedbackVaryings;//!< The varyings that will be captured using a transform feedback. Ordered in the order of capturing.
+	mutable std::unordered_map< std::string, GLint > uniformLocations;//!< Cache of uniform name -> location for the currently linked programID, populated lazily by FindUniform.
 };
 
 }//End namespace ffglex


### PR DESCRIPTION
`FFGLShader::FindUniform` called `glGetUniformLocation` unconditionally on every call. Every `Set(...)`
overload routes through it, so a plugin setting a uniform every frame (e.g. `Particles`, which calls
`FindUniform` by name around 19 times per frame across two shaders) paid a string-keyed driver round-trip per
uniform per frame, per instance, for no benefit: a uniform's location is fixed for the lifetime of a linked
program.

Adds a `name → location` cache to `FFGLShader`, populated lazily in `FindUniform` and invalidated (cleared)
whenever the underlying program changes: in `FreeGLResources()`, and defensively at the top of
`LinkProgram()`. No public API change.

Fixes #80.

**Notes for reviewers:**

- **Unbounded cache growth is intentional, not an oversight.** `uniformLocations` never evicts entries. This
  is OK in practice because it's bounded by the number of *distinct uniform names* a given shader declares
 (single digits up to `Particles`' ~19, the largest user in this tree) not by frame count or anything
  that grows over the plugin's lifetime. An eviction policy would add complexity for a cache that already
  self-limits at the shader's actual uniform count.
- **The cache-clear I added at the top of `LinkProgram()` is currently dead code.** I traced every caller of
  `Compile()`/`FreeGLResources()` in this repo (`Add`, `AddSubtract`, `Gradients`, `CustomThumbnail`,
  `Particles`' `GLResources`, `ffglquickstart::Plugin`) and all of them follow the same
  `InitGL → Compile()` then `DeInitGL → FreeGLResources()` lifecycle, once each, per instance, and none of them
  call `Compile()` a second time on an already-linked shader without freeing it first. So today, clearing in
  `FreeGLResources()` alone would be enough to keep the cache correct. I kept the extra clear in
  `LinkProgram()` anyway as cheap insurance: nothing in `FFGLShader`'s public API actually prevents a future
  caller from calling `Compile()` twice without an intervening `FreeGLResources()`, and if that ever
  happened, the old cache entries would silently point at locations from the previous (now-replaced)
  `programID` without this clear. Flagging so it doesn't read as accidental defensive-programming clutter because
  it's addressing a real (if currently unexercised) gap in the class's invariants. Please don't hesitate to flag it for removal anyway, it if you think that it's just premature optimization.