### PR TITLE
Make `ffglquickstart::Plugin::AddParam` return the created param index

### DIFF
--- a/source/lib/ffglquickstart/FFGLPlugin.cpp
+++ b/source/lib/ffglquickstart/FFGLPlugin.cpp
@@ -261,29 +261,31 @@ void Plugin::SetFragmentShader( std::string base )
 	fragmentShaderBase = base;
 }
 
-void Plugin::AddParam( std::shared_ptr< Param > param )
+unsigned int Plugin::AddParam( std::shared_ptr< Param > param )
 {
 	unsigned int new_index = (unsigned int)params.size();
 	SetParamInfo( new_index, param->GetName().c_str(), param->GetType(), param->GetValue() );
 	params.push_back( param );
+	return new_index;
 }
 
-void Plugin::AddParam( std::shared_ptr< ParamRange > param )
+unsigned int Plugin::AddParam( std::shared_ptr< ParamRange > param )
 {
 	unsigned int new_index = (unsigned int)params.size();
 	SetParamInfo( new_index, param->GetName().c_str(), param->GetType(), param->GetValue() );
-	//In FFGLPluginManager.cpp, line 274, SetParamInfo clamps the default value to 0...1 in case of FF_TYPE_STANDARD 
+	//In FFGLPluginManager.cpp, line 274, SetParamInfo clamps the default value to 0...1 in case of FF_TYPE_STANDARD
 	if( param->GetValue() < 0.0f || param->GetValue() > 1.0f )
 	{
 		ParamInfo* paramInfo = FindParamInfo( new_index );
-		if ( paramInfo != nullptr ) 
+		if ( paramInfo != nullptr )
 			paramInfo->defaultFloatVal = param->GetValue();
 	}
 	SetParamRange( new_index, param->GetRange().min, param->GetRange().max );
 	params.push_back( param );
+	return new_index;
 }
 
-void Plugin::AddParam( std::shared_ptr< ParamOption > param )
+unsigned int Plugin::AddParam( std::shared_ptr< ParamOption > param )
 {
 	unsigned int new_index = (unsigned int)params.size();
 	SetOptionParamInfo( new_index, param->GetName().c_str(), (unsigned int)param->options.size(), param->GetValue() );
@@ -293,14 +295,16 @@ void Plugin::AddParam( std::shared_ptr< ParamOption > param )
 		SetParamElementInfo( new_index, i, param->options[ i ].name.c_str(), (float)i );
 	}
 	params.push_back( param );
+	return new_index;
 }
 
-void Plugin::AddParam( std::shared_ptr< ParamFFT > param )
+unsigned int Plugin::AddParam( std::shared_ptr< ParamFFT > param )
 {
 	audioParams[ param ] = Audio();
 	param->index         = (unsigned int)params.size();
 	SetBufferParamInfo( param->index, param->GetName().c_str(), static_cast< unsigned int >( param->fftData.size() ), FF_USAGE_FFT );
 	params.push_back( param );
+	return param->index;
 }
 
 void Plugin::AddHueColorParam( std::string name )

--- a/source/lib/ffglquickstart/FFGLPlugin.h
+++ b/source/lib/ffglquickstart/FFGLPlugin.h
@@ -151,17 +151,21 @@ public:
 	/// It also allows the plugin to automatically pass the current value of each parameters to the
 	/// shader before drawing.
 	/// \param	param		The parameter to add
-	void AddParam( std::shared_ptr< Param > param );
+	/// \return	The index the param was added at.
+	unsigned int AddParam( std::shared_ptr< Param > param );
 	/// This function handle the special case where the parameter is a ParamRange
 	/// \param	param		The parameter to add
-	void AddParam( std::shared_ptr< ParamRange > param );
+	/// \return	The index the param was added at.
+	unsigned int AddParam( std::shared_ptr< ParamRange > param );
 	/// This function handle the special case where the parameter is a ParamOption (When you have the
 	/// choice between different option).
 	/// \param	param		The parameter to add
-	void AddParam( std::shared_ptr< ParamOption > param );
+	/// \return	The index the param was added at.
+	unsigned int AddParam( std::shared_ptr< ParamOption > param );
 	/// This function handle the special case where the parameter is a ParamFFT
 	/// \param	param		The parameter to add
-	void AddParam( std::shared_ptr< ParamFFT > fft );
+	/// \return	The index the param was added at.
+	unsigned int AddParam( std::shared_ptr< ParamFFT > fft );
 	/// This function allows to create a Hue color param, for exemple in Resolume this will display a
 	/// color picker, which is very handy to choose your color.
 	/// \param	name		The name of the parameter to add


### PR DESCRIPTION
All four `Plugin::AddParam` overloads (`source/lib/ffglquickstart/FFGLPlugin.cpp:264-304`) already compute
the index where a new param is stored at, and use it internally to register the param with the host, then they discard it.
That leaves a caller with no way to learn a param's index afterward, so they can't call the inherited
`CFFGLPluginManager::SetParamGroup`/`SetParamDisplayName` (both index-keyed) without independently
reconstructing the index, e.g. assuming a fixed add order and counting by hand.

This PR changes the four `AddParam` overloads from `void` to `unsigned int`, to return the already-computed index
(`param->index` for the `ParamFFT` overload, `new_index` for the other three). Existing call sites keep compiling and behaving identically whether they capture the return value or not, so this should be 100% backwards compatible.

Fixes #69.